### PR TITLE
Add a new static token type to Syn

### DIFF
--- a/conf/syn-settings.example.xml
+++ b/conf/syn-settings.example.xml
@@ -22,4 +22,12 @@ my secret key
   -->
   <site algorithm='RS256' encoding='PEM' path='/somewhere/on/filesystem.key' default='true'/>
 
+  <!--
+  This lets you specify a master token for testing. This should be used with care, as it gives anyone
+  with this token unlimited access to your repository.
+  -->
+  <token user='test' roles='role1,role2,role3'>
+    my super secret token
+  </token>
+
 </sites>

--- a/src/main/java/ca/islandora/syn/settings/Sites.java
+++ b/src/main/java/ca/islandora/syn/settings/Sites.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class Sites {
     private int version = -1;
     private List<Site> sites = new ArrayList<>();
+    private List<Token> tokens = new ArrayList<>();
 
     public void addSite(final Site site) {
         sites.add(site);
@@ -19,5 +20,12 @@ public class Sites {
     }
     public void setVersion(final int version) {
         this.version = version;
+    }
+
+    public void addToken(final Token token) {
+        tokens.add(token);
+    }
+    public List<Token> getTokens() {
+        return tokens;
     }
 }

--- a/src/main/java/ca/islandora/syn/settings/Token.java
+++ b/src/main/java/ca/islandora/syn/settings/Token.java
@@ -1,0 +1,39 @@
+package ca.islandora.syn.settings;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Token {
+    private String user = "islandoraAdmin";
+    private List<String> roles = new ArrayList<>();
+    private String token = "";
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(final String user) {
+        this.user = user;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(final String roles) {
+        this.roles.clear();
+        if (!roles.isEmpty()) {
+            final String[] parts = roles.split(",");
+            Collections.addAll(this.roles,parts);
+        }
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(final String token) {
+        this.token = token.trim();
+    }
+}

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserTokenTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserTokenTest.java
@@ -1,0 +1,82 @@
+package ca.islandora.syn.settings;
+
+import org.junit.Test;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SettingsParserTokenTest {
+    @Test
+    public void testInvalidVersion() throws Exception {
+        final String testXml = String.join("\n"
+                , "<sites version='2'>"
+                , "  <token>"
+                , "   c00lpazzward"
+                , "  </token>"
+                , "</sites>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        assertEquals(0, tokens.size());
+    }
+
+    @Test
+    public void testTokenNoParams() throws Exception {
+        final String testXml = String.join("\n"
+                , "<sites version='1'>"
+                , "  <token>"
+                , "   c00lpazzward"
+                , "  </token>"
+                , "</sites>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Token token = tokens.get("c00lpazzward");
+        assertEquals(1, tokens.size());
+        assertEquals("c00lpazzward", token.getToken());
+        assertEquals("islandoraAdmin", token.getUser());
+        assertEquals(0, token.getRoles().size());
+    }
+
+    @Test
+    public void testTokenUser() throws Exception {
+        final String testXml = String.join("\n"
+                , "<sites version='1'>"
+                , "  <token user='denis'>"
+                , "   c00lpazzward"
+                , "  </token>"
+                , "</sites>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Token token = tokens.get("c00lpazzward");
+        assertEquals(1, tokens.size());
+        assertEquals("denis", token.getUser());
+    }
+
+    @Test
+    public void testTokenRole() throws Exception {
+        final String testXml = String.join("\n"
+                , "<sites version='1'>"
+                , "  <token roles='role1,role2,role3'>"
+                , "   c00lpazzward"
+                , "  </token>"
+                , "</sites>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Token token = tokens.get("c00lpazzward");
+        assertEquals(1, tokens.size());
+        assertEquals(3, token.getRoles().size());
+        assertTrue(token.getRoles().contains("role1"));
+        assertTrue(token.getRoles().contains("role2"));
+        assertTrue(token.getRoles().contains("role3"));
+    }
+}

--- a/src/test/java/ca/islandora/syn/settings/SitesTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SitesTest.java
@@ -18,4 +18,14 @@ public class SitesTest {
         assertEquals(1, sites.getSites().size());
         assertEquals(site, sites.getSites().get(0));
     }
+
+    @Test
+    public void TestToken() {
+        final Sites sites = new Sites();
+        final Token token = new Token();
+        assertEquals(0, sites.getTokens().size());
+        sites.addToken(token);
+        assertEquals(1, sites.getTokens().size());
+        assertEquals(token, sites.getTokens().get(0));
+    }
 }

--- a/src/test/java/ca/islandora/syn/settings/TokenTest.java
+++ b/src/test/java/ca/islandora/syn/settings/TokenTest.java
@@ -1,0 +1,50 @@
+package ca.islandora.syn.settings;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TokenTest {
+    Token token;
+
+    @Before
+    public void initializeSite() {
+        this.token = new Token();
+    }
+
+    @Test
+    public void testTokenUser() {
+        assertEquals("islandoraAdmin", this.token.getUser());
+        final String testVal = "test";
+        this.token.setUser(testVal);
+        assertEquals(testVal, this.token.getUser());
+    }
+
+    @Test
+    public void testTokenRoles() {
+        assertEquals(0, this.token.getRoles().size());
+
+        this.token.setRoles("test");
+        assertEquals(1, this.token.getRoles().size());
+        assertEquals("test", this.token.getRoles().get(0));
+
+        this.token.setRoles("this,is,a,test");
+        assertEquals(4, this.token.getRoles().size());
+        assertEquals("this", this.token.getRoles().get(0));
+        assertEquals("is", this.token.getRoles().get(1));
+        assertEquals("a", this.token.getRoles().get(2));
+        assertEquals("test", this.token.getRoles().get(3));
+    }
+
+    @Test
+    public void testTokenToken() {
+        assertTrue(this.token.getToken().isEmpty());
+        final String testVal = "test";
+        this.token.setToken(testVal);
+        assertEquals(testVal, this.token.getToken());
+        this.token.setToken("   " + testVal);
+        assertEquals(testVal, this.token.getToken());
+    }
+}


### PR DESCRIPTION
## GitHub Issue

Part of:
https://github.com/Islandora-CLAW/CLAW/issues/573

## What does this Pull Request do?

This commit adds the ability to set a static token in the Syn configuration file so that you can easily use a token for testing, connecting to fedora etc. Should make testing things a little easier. If you set your browser to send the token header you can also use the Fedora web interface again, which is nice.

## How should this be tested?

- Merge in this pull request
- Build and install Syn jar
- modify `/var/lib/tomcat8/conf/syn-settings.xml` to contain:
```
<sites version='1'>
        <site algorithm='RS256' encoding='PEM' path='/home/ubuntu/auth/public.key' default='true'/>
        <token>secretToken</token>
</sites>
```
- Try to curl to fedora with `-H "Authorization: Bearer secretToken"` and make sure it is accepted.