### PR TITLE
Use local timezones for non-Unix OSes.

### DIFF
--- a/src/test/java/ca/islandora/syn/token/VerifierTest.java
+++ b/src/test/java/ca/islandora/syn/token/VerifierTest.java
@@ -2,23 +2,35 @@ package ca.islandora.syn.token;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import org.junit.Test;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAKey;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
 public class VerifierTest {
 
     private static String token;
+
+    private static ZoneOffset offset;
+
+    @Before
+    public void setUp() {
+        offset = ZoneId.systemDefault().getRules().getOffset(Instant.now());
+    }
 
     @Test
     public void testClaimsWithoutVerify() {
@@ -27,8 +39,8 @@ public class VerifierTest {
                 .withClaim("uid", 1)
                 .withClaim("name", "admin")
                 .withClaim("url", "http://test.com")
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.none());
         final Verifier verifier = Verifier.create(token);
         assertEquals(1, verifier.getUid());
@@ -64,8 +76,8 @@ public class VerifierTest {
                 .withClaim("uid", 1)
                 .withClaim("name", "admin")
                 .withClaim("url", "http://test.com")
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
 
         final Verifier verifier = Verifier.create(token);
@@ -93,8 +105,8 @@ public class VerifierTest {
                 .withClaim("uid", 1)
                 .withClaim("name", "admin")
                 .withClaim("url", "http://test.com")
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.RSA512(privateKey));
 
         final Verifier verifier = Verifier.create(token);
@@ -117,8 +129,8 @@ public class VerifierTest {
                 .withClaim("uid", 1)
                 .withClaim("name", "admin")
                 .withClaim("url", "http://test.com")
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().minusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().minusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
 
         final Verifier verifier = Verifier.create(token);

--- a/src/test/java/ca/islandora/syn/valves/SynValveTest.java
+++ b/src/test/java/ca/islandora/syn/valves/SynValveTest.java
@@ -23,7 +23,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
@@ -62,6 +64,8 @@ public class SynValveTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    private static ZoneOffset offset;
+
     @Before
     public void setUp() throws Exception {
         settings = temporaryFolder.newFile();
@@ -74,6 +78,7 @@ public class SynValveTest {
 
         when(container.getRealm()).thenReturn(realm);
         when(request.getContext()).thenReturn(context);
+        offset = ZoneId.systemDefault().getRules().getOffset(Instant.now());
     }
 
     @Test
@@ -97,8 +102,8 @@ public class SynValveTest {
                 .withClaim("name", "adminuser")
                 .withClaim("url", "http://test.com")
                 .withArrayClaim("roles", new String[] {"role1", "role2", "role3"})
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
 
         final SecurityConstraint securityConstraint = new SecurityConstraint();
@@ -208,8 +213,8 @@ public class SynValveTest {
                 .withClaim("name", "adminuser")
                 .withClaim("url", "http://test.com")
                 .withArrayClaim("roles", new String[] {"role1", "role2", "role3"})
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
 
         final SecurityConstraint securityConstraint = new SecurityConstraint();
@@ -234,8 +239,8 @@ public class SynValveTest {
                 .withClaim("name", "normalUser")
                 .withClaim("url", "http://test2.com")
                 .withArrayClaim("roles", new String[] {})
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret2"));
 
         final ArgumentCaptor<GenericPrincipal> argument = ArgumentCaptor.forClass(GenericPrincipal.class);
@@ -272,8 +277,8 @@ public class SynValveTest {
                 .withClaim("name", "normalUser")
                 .withClaim("url", "http://test-no-match.com")
                 .withArrayClaim("roles", new String[] {})
-                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)))
-                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.UTC)))
+                .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
+                .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
 
         final SecurityConstraint securityConstraint = new SecurityConstraint();


### PR DESCRIPTION
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/614

# What does this Pull Request do?

Tests were using UTC timezone to set `expiresAt`, which works in Linux as the system clock is always UTC. But on a Mac, I get a local timezone time. This causes test failures.

# What's new?

Generate a local ZoneOffset based on system timezone.

# How should this be tested?

`./gradlew build` on a non-Linux OS

# Interested parties
@jonathangreen @ajs6f @dannylamb 