### PR TITLE
Add attribute to allow anonymous GET requests through Syn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 *.ipr
 *.iws
+/bin/

--- a/conf/syn-settings.example.xml
+++ b/conf/syn-settings.example.xml
@@ -16,6 +16,9 @@ my secret key
   <!-- A site with a key stored in a file -->
   <site url='http://test2.com' algorithm='HS256' encoding='base64' path='/somewhere/on/filesystem.key'/>
 
+  <!-- A site that allows all GET requests  -->
+  <site url='http://test3.com' algorithm='HS256' encoding='plain' anonymous='true'/>
+
   <!-- 
   This is how you specify a default site, which will be chosen if no 
   other site matches the JWT url claim

--- a/src/main/java/ca/islandora/syn/settings/Site.java
+++ b/src/main/java/ca/islandora/syn/settings/Site.java
@@ -7,6 +7,7 @@ public class Site {
     private String path = null;
     private String encoding = null;
     private boolean defaultItem = false;
+    private boolean allowAnonymous = false;
 
     public String getUrl() {
         return this.url;
@@ -48,5 +49,23 @@ public class Site {
     }
     public void setDefault(final boolean defaultItem) {
         this.defaultItem = defaultItem;
+    }
+
+    /**
+     * Allow GET requests without a token that match this site.
+     *
+     * @return whether to allow the request
+     */
+    public boolean getAnonymous() {
+        return this.allowAnonymous;
+    }
+
+    /**
+     * Set allow GET requests with a token that match this site.
+     *
+     * @param allowAnonGet boolean whether to allow these requests.
+     */
+    public void setAnonymous(final boolean allowAnonGet) {
+        this.allowAnonymous = allowAnonGet;
     }
 }

--- a/src/main/java/ca/islandora/syn/valve/SynValve.java
+++ b/src/main/java/ca/islandora/syn/valve/SynValve.java
@@ -1,16 +1,15 @@
 package ca.islandora.syn.valve;
 
-import ca.islandora.syn.settings.SettingsParser;
-import ca.islandora.syn.settings.Token;
-import ca.islandora.syn.token.Verifier;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
-import com.auth0.jwt.algorithms.Algorithm;
+
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
@@ -20,12 +19,20 @@ import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
 
+import com.auth0.jwt.algorithms.Algorithm;
+
+import ca.islandora.syn.settings.SettingsParser;
+import ca.islandora.syn.settings.Token;
+import ca.islandora.syn.token.Verifier;
+
 public class SynValve extends ValveBase {
 
     private String pathname = "conf/syn-settings.xml";
     private static final Log log = LogFactory.getLog(SynValve.class);
     private Map<String, Algorithm> algorithmMap = null;
     private Map<String, Token> staticTokenMap = null;
+
+    private Map<String, Boolean> anonymousGetMap = null;
 
     @Override
     public void invoke(final Request request, final Response response)
@@ -36,7 +43,7 @@ public class SynValve extends ValveBase {
 
         if ((constraints == null
                 && !request.getContext().getPreemptiveAuthentication())
-                || !hasAuthConstraint(constraints)) {
+            || !hasAuthConstraint(constraints)) {
             this.getNext().invoke(request, response);
         } else {
             handleAuthentication(request, response);
@@ -105,6 +112,15 @@ public class SynValve extends ValveBase {
         }
     }
 
+    private void setAnonymousRoles(final Request request) {
+        final List<String> roles = new ArrayList<String>();
+        roles.add("anonymous");
+        roles.add("islandora");
+        final String name = "anonymous";
+        final GenericPrincipal principal = new GenericPrincipal(name, null, roles);
+        request.setUserPrincipal(principal);
+    }
+
     private void setUserRolesFromStaticToken(final Request request, final Token token) {
         final List<String> roles = token.getRoles();
         roles.add("islandora");
@@ -124,11 +140,37 @@ public class SynValve extends ValveBase {
 
     private void handleAuthentication(final Request request, final Response response)
             throws IOException, ServletException {
-        if (doAuthentication(request)) {
+        if (request.getMethod().equalsIgnoreCase("GET") &&
+            allowGetRequests(request.getHost().toString())) {
+            // Skip authentication
+            setAnonymousRoles(request);
+            this.getNext().invoke(request, response);
+        } else if (doAuthentication(request)) {
             this.getNext().invoke(request, response);
         } else {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token authentication failed.");
         }
+    }
+
+    /**
+     * Do the logic of allowing GET
+     *
+     * @param requestURI the site being requested
+     * @return whether to allow GET requests without authentication.
+     */
+    private boolean allowGetRequests(final String requestURI) {
+        // If there is a matching site URI and it allows anonymous, return true
+        if (anonymousGetMap.containsKey(requestURI) && anonymousGetMap.get(requestURI)) {
+            log.debug(String.format("Allowing all GET requests for site {}", requestURI));
+            return true;
+            // If default is 'allow' and there is no matching site to 'deny', return true.
+        } else if (anonymousGetMap.get("default") &&
+            (anonymousGetMap.containsKey(requestURI) && anonymousGetMap.get(requestURI)) ||
+            (!anonymousGetMap.containsKey(requestURI))) {
+            log.debug(String.format("GET requests allowed by default, not deny for  {}", requestURI));
+            return true;
+        }
+        return false;
     }
 
     public String getPathname() {
@@ -155,6 +197,7 @@ public class SynValve extends ValveBase {
         try {
             this.algorithmMap = SettingsParser.getSiteAlgorithms(new FileInputStream(file));
             this.staticTokenMap = SettingsParser.getSiteStaticTokens(new FileInputStream(file));
+            this.anonymousGetMap = SettingsParser.getSiteAllowAnonymous(new FileInputStream(file));
         } catch (Exception e) {
             throw new LifecycleException("Error parsing XML Configuration", e);
         }

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserAnonymousTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserAnonymousTest.java
@@ -1,0 +1,76 @@
+package ca.islandora.syn.settings;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class SettingsParserAnonymousTest {
+
+    @Test
+    public void testSiteAnonymousOn() throws Exception {
+        final String testXml = String.join("\n"
+            , "<config version='1'>"
+            , "  <site url='http://test.com' algorithm='RS256' encoding='plain' anonymous='true'>"
+            , "   test data"
+            , "  </site>"
+            , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        assertEquals(1, anonymous.size());
+        assertEquals(true, anonymous.containsKey("http://test.com"));
+        assertEquals(true, anonymous.get("http://test.com"));
+    }
+
+    @Test
+    public void testSiteMultipleAnonymousTest() throws Exception {
+        final String testXml = String.join("\n"
+            , "<config version='1'>"
+            , "  <site url='http://test.com' algorithm='RS256' encoding='plain' anonymous='true'>"
+            , "   test data"
+            , "  </site>"
+            , "  <site url='http://test2.com' algorithm='RS256' encoding='plain' anonymous='false'>"
+            , "   test data"
+            , "  </site>"
+            , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        assertEquals(2, anonymous.size());
+        assertEquals(true, anonymous.containsKey("http://test.com"));
+        assertEquals(true, anonymous.get("http://test.com"));
+        assertEquals(true, anonymous.containsKey("http://test2.com"));
+        assertEquals(false, anonymous.get("http://test2.com"));
+    }
+
+    @Test
+    public void testDefaultMultipleAnonymousTest() throws Exception {
+        final String testXml = String.join("\n"
+            , "<config version='1'>"
+            , "  <site url='http://test.com' algorithm='RS256' encoding='plain' anonymous='true'>"
+            , "   test data"
+            , "  </site>"
+            , "  <site url='http://test2.com' algorithm='RS256' encoding='plain' anonymous='false'>"
+            , "   test data"
+            , "  </site>"
+            , "  <site algorithm='RS256' encoding='plain' anonymous='true' default='true'/>"
+            , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        assertEquals(3, anonymous.size());
+        assertEquals(true, anonymous.containsKey("http://test.com"));
+        assertEquals(true, anonymous.get("http://test.com"));
+        assertEquals(true, anonymous.containsKey("http://test2.com"));
+        assertEquals(false, anonymous.get("http://test2.com"));
+        assertEquals(true, anonymous.containsKey("default"));
+        assertEquals(true, anonymous.get("default"));
+    }
+}

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserDigestTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserDigestTest.java
@@ -1,14 +1,14 @@
 package ca.islandora.syn.settings;
 
-import org.junit.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.Test;
 
 public class SettingsParserDigestTest {
 
@@ -25,7 +25,7 @@ public class SettingsParserDigestTest {
         assertEquals(12, settings.getVersion());
         assertEquals(1, settings.getSites().size());
 
-        final Site site = (Site) settings.getSites().get(0);
+        final Site site = settings.getSites().get(0);
         assertEquals("RS384", site.getAlgorithm());
         assertEquals("http://test.com", site.getUrl());
         assertEquals("test/path.key", site.getPath());
@@ -50,7 +50,7 @@ public class SettingsParserDigestTest {
         assertEquals(-1, settings.getVersion());
         assertEquals(1, settings.getSites().size());
 
-        final Site site = (Site) settings.getSites().get(0);
+        final Site site = settings.getSites().get(0);
         assertEquals("RS384", site.getAlgorithm());
         assertEquals("http://test.com", site.getUrl());
         assertNull(site.getPath());
@@ -95,5 +95,44 @@ public class SettingsParserDigestTest {
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
         final Config settings = SettingsParser.getSitesObject(stream);
+    }
+
+    @Test
+    public void testValidAnonymousTrue() throws Exception {
+        final String testXml = "<config>\n" +
+            "  <site url=\"http://test.com\" algorithm=\"RS384\" encoding=\"PEM\" default=\"true\" " +
+            "anonymous=\"true\" />\n" +
+            "</config>";
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        final Site sites = settings.getSites().get(0);
+        assertTrue("Did not set anonymous property", sites.getAnonymous());
+    }
+
+    @Test
+    public void testValidAnonymousFalse() throws Exception {
+        final String testXml = "<config>\n" +
+            "  <site url=\"http://test.com\" algorithm=\"RS384\" encoding=\"PEM\" default=\"true\" " +
+            "anonymous=\"false\" />\n" +
+            "</config>";
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        final Site sites = settings.getSites().get(0);
+        assertFalse("Did not set anonymous property", sites.getAnonymous());
+    }
+
+    @Test
+    public void testInvalidAnonymous() throws Exception {
+        final String testXml = "<config>\n" +
+            "  <site url=\"http://test.com\" algorithm=\"RS384\" encoding=\"PEM\" default=\"true\" " +
+            "anonymous=\"whatever\" />\n" +
+            "</config>";
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        final Site sites = settings.getSites().get(0);
+        assertFalse("Did not set anonymous property", sites.getAnonymous());
     }
 }

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserDigestTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserDigestTest.java
@@ -83,6 +83,7 @@ public class SettingsParserDigestTest {
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
         final Config settings = SettingsParser.getSitesObject(stream);
+        assertEquals(1, settings.getSites().size());
     }
 
     @Test
@@ -95,7 +96,8 @@ public class SettingsParserDigestTest {
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
         final Config settings = SettingsParser.getSitesObject(stream);
-    }
+        assertEquals(0, settings.getSites().size())
+;    }
 
     @Test
     public void testValidAnonymousTrue() throws Exception {

--- a/src/test/java/ca/islandora/syn/settings/SiteTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SiteTest.java
@@ -1,12 +1,12 @@
 package ca.islandora.syn.settings;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
 
 public class SiteTest {
     Site site;
@@ -63,5 +63,14 @@ public class SiteTest {
         assertTrue(this.site.getDefault());
         this.site.setDefault(false);
         assertFalse(this.site.getDefault());
+    }
+
+    @Test
+    public void testSiteAnonymous() {
+        assertFalse(this.site.getAnonymous());
+        this.site.setAnonymous(true);
+        assertTrue(this.site.getAnonymous());
+        this.site.setAnonymous(false);
+        assertFalse(this.site.getAnonymous());
     }
 }


### PR DESCRIPTION
Partially resolves: https://github.com/Islandora-CLAW/CLAW/issues/573

# What does this Pull Request do?

Adds another attribute to the `site` element `anonymous="(true|false)"`, to allow you to set some or all sites to allow unauthenticated GET requests.

# What's new?
This does not clean up the XML validation issues I expressed [here](https://github.com/Islandora-CLAW/CLAW/issues/573#issuecomment-298145175), but I figured those could be dealt with later.

This adds in the third parsing of the XML files to generate a map of URL and anonymous check, if a site URL matches the host that is the option used, or if the default is set and no site is specified that is what is used.

Sets credentials as `anonymous` with roles of `anonymous` and `islandora`. 

Not sure if there is a way to avoid authentication once you have required it, like to avoid creating sessions like @jonathangreen was suggesting. That can come later.

# How should this be tested?

1. Pull this branch into your claw_vagrant
2. Run `./gradlew clean build`
3. Copy the `build/lib/islandora-syn-0.0.1-all.jar` to `/var/lib/tomcat8/lib`
4. Edit your `/var/lib/tomcat8/conf/syn-settings.xml` sites file include an `anonymous='true'` option.
5. Restart tomcat

You should be able to access `http://localhost:8080/fcrepo/rest` without a token, but a POST request will still fail.

# Interested parties
@jonathangreen @ajs6f @dannylamb 