### PR TITLE
Alter Valve to send roles via Http header

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ On ubuntu this file can be found at:
 ### Setup Syn Configuration
 Modify the [example configuration](./conf/syn-settings.example.xml) and move it to: `$CATALINA_BASE/conf/syn-settings.xml`.
 
+### Header principals
+Additional roles are passed to Fedora via a HTTP header, this is configured via the `header` attribute to the `<config>` element in the syn-settings.xml.example file. You must also configure Fedora to read this header via its HeaderProvider.
+
 ## Maintainers
 
 * [Jonathan Green](https://github.com/jonathangreen/)

--- a/conf/syn-settings.example.xml
+++ b/conf/syn-settings.example.xml
@@ -1,4 +1,4 @@
-<config version='1'>
+<config version='1' header="X-Islandora-Roles">
   <!-- 
   Sites can be specified with a Key inline, or with a reference to a key 
   stored in a file. Both are shown in examples below.

--- a/src/main/java/ca/islandora/syn/settings/Config.java
+++ b/src/main/java/ca/islandora/syn/settings/Config.java
@@ -5,8 +5,9 @@ import java.util.List;
 
 public class Config {
     private int version = -1;
-    private List<Site> sites = new ArrayList<>();
-    private List<Token> tokens = new ArrayList<>();
+    private String header = "";
+    private final List<Site> sites = new ArrayList<>();
+    private final List<Token> tokens = new ArrayList<>();
 
     public void addSite(final Site site) {
         sites.add(site);
@@ -27,5 +28,13 @@ public class Config {
     }
     public List<Token> getTokens() {
         return tokens;
+    }
+
+    public void setHeader(final String header) {
+        this.header = header;
+    }
+
+    public String getHeader() {
+        return this.header;
     }
 }

--- a/src/main/java/ca/islandora/syn/settings/SettingsParser.java
+++ b/src/main/java/ca/islandora/syn/settings/SettingsParser.java
@@ -94,7 +94,7 @@ public final class SettingsParser {
         } else if (site.getPath() != null) {
             try {
                 publicKeyReader = new FileReader(site.getPath());
-            } catch (FileNotFoundException e) {
+            } catch (final FileNotFoundException e) {
                 log.error("Private key file not found.");
             }
         }
@@ -112,7 +112,7 @@ public final class SettingsParser {
                 publicKey = (RSAPublicKey) factory.generatePublic(pubKeySpec);
                 pemReader.close();
                 publicKeyReader.close();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 log.error("Error loading public key.");
                 return null;
             }
@@ -134,7 +134,7 @@ public final class SettingsParser {
     }
 
     private static Algorithm getHmacAlgorithm(final Site site) {
-        byte[] secret;
+        final byte[] secret;
         byte[] secretRaw = null;
 
         if (!site.getKey().equalsIgnoreCase("")) {
@@ -142,7 +142,7 @@ public final class SettingsParser {
         } else if (site.getPath() != null) {
             try {
                 secretRaw = Files.readAllBytes(Paths.get(site.getPath()));
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 log.error("Unable to get secret from file.", e);
             }
         }
@@ -154,7 +154,7 @@ public final class SettingsParser {
         if (site.getEncoding().equalsIgnoreCase("base64")) {
             try {
                 secret = Base64.getDecoder().decode(secretRaw);
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 log.error("Base64 decode error. Skipping site.", e);
                 return null;
             }
@@ -175,12 +175,19 @@ public final class SettingsParser {
         }
     }
 
-    private static Config getSites(final InputStream settings) {
-        Config sites;
+    /**
+     * Parse a configuration file and return a Config object
+     *
+     * @param settings
+     *        The configuration file stream
+     * @return the config object
+     */
+    public static Config getSites(final InputStream settings) {
+        final Config sites;
 
         try {
             sites = getSitesObject(settings);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error("Error loading settings file.", e);
             return null;
         }
@@ -193,16 +200,22 @@ public final class SettingsParser {
         return sites;
     }
 
-    public static Map<String, Algorithm> getSiteAlgorithms(final InputStream settings) {
+    /**
+     * Get algorithms for sites
+     *
+     * @param sites
+     *        configuration with sites
+     * @return map of site url (or null for default) and algorithm
+     */
+    public static Map<String, Algorithm> getSiteAlgorithms(final Config sites) {
         final Map<String, Algorithm> algorithms = new HashMap<>();
-        final Config sites = getSites(settings);
         if (sites == null) {
             return algorithms;
         }
 
         boolean defaultSet = false;
 
-        for (Site site : sites.getSites()) {
+        for (final Site site : sites.getSites()) {
             final boolean pathDefined = site.getPath() != null && !site.getPath().equalsIgnoreCase("");
             final boolean keyDefined = site.getKey() != null && !site.getKey().equalsIgnoreCase("");
 
@@ -220,7 +233,7 @@ public final class SettingsParser {
 
             // Check that the algorithm type is valid.
             final AlgorithmType algorithmType = getSiteAlgorithmType(site.getAlgorithm());
-            Algorithm algorithm;
+            final Algorithm algorithm;
             if (algorithmType == AlgorithmType.HMAC) {
                 algorithm = getHmacAlgorithm(site);
             } else if (algorithmType == AlgorithmType.RSA) {
@@ -252,8 +265,14 @@ public final class SettingsParser {
         return algorithms;
     }
 
-    public static Map<String, Token> getSiteStaticTokens(final InputStream settings) {
-        final Config sites = getSites(settings);
+    /**
+     * Get the site static tokens from a set of sites in the configuration
+     *
+     * @param sites
+     *        the configured sites
+     * @return map of token string and token object
+     */
+    public static Map<String, Token> getSiteStaticTokens(final Config sites) {
         if (sites == null) {
             return new HashMap<String, Token>();
         }
@@ -267,11 +286,11 @@ public final class SettingsParser {
     /**
      * Build a list of site urls that allow anonymous GET requests.
      *
-     * @param settings the path to the syn-settings file
+     * @param sites
+     *        a config object with the site information
      * @return list of site urls.
      */
-    public static Map<String, Boolean> getSiteAllowAnonymous(final InputStream settings) {
-        final Config sites = getSites(settings);
+    public static Map<String, Boolean> getSiteAllowAnonymous(final Config sites) {
         if (sites == null) {
             return new HashMap<String, Boolean>();
         }

--- a/src/main/java/ca/islandora/syn/token/Verifier.java
+++ b/src/main/java/ca/islandora/syn/token/Verifier.java
@@ -1,11 +1,16 @@
 package ca.islandora.syn.token;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+
 import org.apache.juli.logging.Log;
 import org.apache.juli.logging.LogFactory;
 
@@ -19,28 +24,18 @@ public class Verifier {
 
     public static Verifier create(final String token) {
         final Verifier verifier = new Verifier();
+        final List<String> requiredClaims = Arrays.asList("sub", "iss", "webid", "roles", "exp", "iat");
         verifier.token = token;
         try {
             verifier.jwt = JWT.decode(token);
-            if (verifier.jwt.getClaim("uid").isNull()) {
-                return null;
+            final Map<String, Claim> claims = verifier.jwt.getClaims();
+            for (final String claim : requiredClaims) {
+                if (claims.get(claim) == null) {
+                    log.debug(String.format("Token missing required claim ({})", claim));
+                    return null;
+                }
             }
-            if (verifier.jwt.getClaim("url").isNull()) {
-                return null;
-            }
-            if (verifier.jwt.getClaim("name").isNull()) {
-                return null;
-            }
-            if (verifier.jwt.getClaim("roles").isNull()) {
-                return null;
-            }
-            if (verifier.jwt.getExpiresAt() == null) {
-                return null;
-            }
-            if (verifier.jwt.getIssuedAt() == null) {
-                return null;
-            }
-        } catch (JWTDecodeException exception) {
+        } catch (final JWTDecodeException exception) {
             log.error("Error decoding token: " + token, exception);
             return null;
         }
@@ -48,15 +43,15 @@ public class Verifier {
     }
 
     public int getUid() {
-        return this.jwt.getClaim("uid").asInt();
+        return this.jwt.getClaim("webid").asInt();
     }
 
     public String getUrl() {
-        return this.jwt.getClaim("url").asString();
+        return this.jwt.getClaim("iss").asString();
     }
 
     public String getName() {
-        return this.jwt.getClaim("name").asString();
+        return this.jwt.getClaim("sub").asString();
     }
 
     public List<String> getRoles() {
@@ -67,7 +62,7 @@ public class Verifier {
         final JWTVerifier verifier = JWT.require(algorithm).build();
         try {
             verifier.verify(this.token);
-        } catch (JWTVerificationException exception) {
+        } catch (final JWTVerificationException exception) {
             return false;
         }
 

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserAlgorithmsTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserAlgorithmsTest.java
@@ -29,7 +29,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
         assertEquals(true, algorithms.containsKey("http://test.com"));
         assertEquals(algorithm, algorithms.get("http://test.com").getName());
@@ -53,7 +53,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -68,7 +68,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
     }
 
@@ -83,7 +83,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -98,7 +98,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -113,7 +113,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
         assertEquals(true, algorithms.containsKey("http://test.com"));
         assertEquals(algorithm, algorithms.get("http://test.com").getName());
@@ -137,7 +137,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -150,7 +150,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -163,7 +163,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -178,7 +178,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
     }
 
@@ -193,7 +193,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -212,7 +212,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
         assertEquals(true, algorithms.containsKey("http://test.com"));
         assertEquals(algorithm, algorithms.get("http://test.com").getName());
@@ -247,7 +247,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
         assertEquals(true, algorithms.containsKey("http://test.com"));
         assertEquals(algorithm, algorithms.get("http://test.com").getName());
@@ -271,7 +271,7 @@ public class SettingsParserAlgorithmsTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 
@@ -299,7 +299,7 @@ public class SettingsParserAlgorithmsTest {
             , "</config>"
         );
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(1, algorithms.size());
     }
 
@@ -325,7 +325,7 @@ public class SettingsParserAlgorithmsTest {
             , "</config>"
         );
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Algorithm> algorithms = SettingsParser.getSiteAlgorithms(stream);
+        final Map<String, Algorithm> algorithms = SettingsParser.getSiteAlgorithms(SettingsParser.getSites(stream));
         assertEquals(0, algorithms.size());
     }
 }

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserAnonymousTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserAnonymousTest.java
@@ -21,7 +21,7 @@ public class SettingsParserAnonymousTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(SettingsParser.getSites(stream));
         assertEquals(1, anonymous.size());
         assertEquals(true, anonymous.containsKey("http://test.com"));
         assertEquals(true, anonymous.get("http://test.com"));
@@ -41,7 +41,7 @@ public class SettingsParserAnonymousTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(SettingsParser.getSites(stream));
         assertEquals(2, anonymous.size());
         assertEquals(true, anonymous.containsKey("http://test.com"));
         assertEquals(true, anonymous.get("http://test.com"));
@@ -64,7 +64,7 @@ public class SettingsParserAnonymousTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(stream);
+        final Map<String, Boolean> anonymous = SettingsParser.getSiteAllowAnonymous(SettingsParser.getSites(stream));
         assertEquals(3, anonymous.size());
         assertEquals(true, anonymous.containsKey("http://test.com"));
         assertEquals(true, anonymous.get("http://test.com"));

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserTokenTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserTokenTest.java
@@ -20,8 +20,16 @@ public class SettingsParserTokenTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Map<String, Token> tokens = SettingsParser.getSiteStaticTokens(SettingsParser.getSites(stream));
         assertEquals(0, tokens.size());
+    }
+
+    @Test
+    public void testTokenHeaderName() {
+        final String testXml = String.join("\n", "<config version='1' header='X-Islandora'>", "</config>");
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config config = SettingsParser.getSites(stream);
+        assertEquals("X-Islandora", config.getHeader());
     }
 
     @Test
@@ -35,7 +43,7 @@ public class SettingsParserTokenTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Map<String, Token> tokens = SettingsParser.getSiteStaticTokens(SettingsParser.getSites(stream));
         final Token token = tokens.get("c00lpazzward");
         assertEquals(1, tokens.size());
         assertEquals("c00lpazzward", token.getToken());
@@ -54,7 +62,7 @@ public class SettingsParserTokenTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Map<String, Token> tokens = SettingsParser.getSiteStaticTokens(SettingsParser.getSites(stream));
         final Token token = tokens.get("c00lpazzward");
         assertEquals(1, tokens.size());
         assertEquals("denis", token.getUser());
@@ -71,7 +79,7 @@ public class SettingsParserTokenTest {
         );
 
         final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
-        final Map<String,Token> tokens = SettingsParser.getSiteStaticTokens(stream);
+        final Map<String, Token> tokens = SettingsParser.getSiteStaticTokens(SettingsParser.getSites(stream));
         final Token token = tokens.get("c00lpazzward");
         assertEquals(1, tokens.size());
         assertEquals(3, token.getRoles().size());

--- a/src/test/java/ca/islandora/syn/token/VerifierTest.java
+++ b/src/test/java/ca/islandora/syn/token/VerifierTest.java
@@ -35,10 +35,10 @@ public class VerifierTest {
     @Test
     public void testClaimsWithoutVerify() {
         token = JWT.create()
-                .withArrayClaim("roles", new String[]{"Role1", "Role2"})
-                .withClaim("uid", 1)
-                .withClaim("name", "admin")
-                .withClaim("url", "http://test.com")
+                .withArrayClaim("roles", new String[] { "Role1", "Role2" })
+                .withClaim("webid", 1)
+                .withClaim("sub", "admin")
+                .withClaim("iss", "http://test.com")
                 .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
                 .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.none());
@@ -55,8 +55,8 @@ public class VerifierTest {
     @Test
     public void testClaimsMissing() {
         token = JWT.create()
-                .withClaim("name", "admin")
-                .withClaim("url", "http://test.com")
+                .withClaim("sub", "admin")
+                .withClaim("iss", "http://test.com")
                 .sign(Algorithm.none());
         final Verifier verifier = Verifier.create(token);
         assertNull(verifier);
@@ -72,10 +72,10 @@ public class VerifierTest {
     @Test
     public void testClaimsAndVerifyHmac() throws Exception {
         token = JWT.create()
-                .withArrayClaim("roles", new String[]{"Role1", "Role2"})
-                .withClaim("uid", 1)
-                .withClaim("name", "admin")
-                .withClaim("url", "http://test.com")
+                .withArrayClaim("roles", new String[] { "Role1", "Role2" })
+                .withClaim("webid", 1)
+                .withClaim("sub", "admin")
+                .withClaim("iss", "http://test.com")
                 .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
                 .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));
@@ -101,10 +101,10 @@ public class VerifierTest {
         final RSAKey publicKey = (RSAKey) pair.getPublic();
 
         token = JWT.create()
-                .withArrayClaim("roles", new String[]{"Role1", "Role2"})
-                .withClaim("uid", 1)
-                .withClaim("name", "admin")
-                .withClaim("url", "http://test.com")
+                .withArrayClaim("roles", new String[] { "Role1", "Role2" })
+                .withClaim("webid", 1)
+                .withClaim("sub", "admin")
+                .withClaim("iss", "http://test.com")
                 .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
                 .withExpiresAt(Date.from(LocalDateTime.now().plusHours(2).toInstant(offset)))
                 .sign(Algorithm.RSA512(privateKey));
@@ -125,10 +125,10 @@ public class VerifierTest {
     @Test
     public void testClaimsAndVerifyHmacBadIssueDate() throws Exception {
         token = JWT.create()
-                .withArrayClaim("roles", new String[]{"Role1", "Role2"})
-                .withClaim("uid", 1)
-                .withClaim("name", "admin")
-                .withClaim("url", "http://test.com")
+                .withArrayClaim("roles", new String[] { "Role1", "Role2" })
+                .withClaim("webid", 1)
+                .withClaim("sub", "admin")
+                .withClaim("iss", "http://test.com")
                 .withIssuedAt(Date.from(LocalDateTime.now().toInstant(offset)))
                 .withExpiresAt(Date.from(LocalDateTime.now().minusHours(2).toInstant(offset)))
                 .sign(Algorithm.HMAC256("secret"));

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/966

# What does this Pull Request do?

It moves all Drupal roles into a Http header that is passed to Fedora using its HeaderProvider.

It assigns a single role of `fedoraUser` or `fedoraAdmin` based on whether any of the current user roles match `fedoraAdmin`. Perhaps this should be made configurable in future.

Also when we reverted the SynFilter PR, we reverted the change to accept the standard JWT claims. So I have re-added those changes here.

Lastly we were parsing the `syn-settings.xml` file 3 times, I changed the code to accept a `Config` object. So we just parse once to get that object and pass it to get the various maps.

# What's new?

* Does this change require documentation to be updated? I added some info to the README, but more might be necessary
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

See https://github.com/Islandora-Devops/claw-playbook/pull/86

# Interested parties
@Islandora-CLAW/committers 