### PR TITLE
Improve release automation on 2.x and fix bug with modern `GenericPrincipal`

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -7,8 +7,32 @@ on:
     branches: [ 2.x ]
 
 jobs:
-  build:
+  release-version:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release version
+        run: |
+          git fetch --tags --force origin "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+          bash scripts/validate-release-version.sh
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          REQUIRE_VERSION_BUMP: 'true'
+
+  build:
+    name: Tomcat ${{ matrix.tomcat-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tomcat-version:
+          - '10.1.42'
+          - '11.0.22'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -23,10 +47,12 @@ jobs:
       - name: Gradle Check
         run: |
           cd $GITHUB_WORKSPACE/build_dir
-          ./gradlew check
+          ./gradlew check -PtomcatVersion="${{ matrix.tomcat-version }}"
       - name: Jacoco Test
+        if: matrix.tomcat-version == '11.0.22'
         run: |
           cd $GITHUB_WORKSPACE/build_dir
-          ./gradlew jacocoTestReport
+          ./gradlew jacocoTestReport -PtomcatVersion="${{ matrix.tomcat-version }}"
       - name: Codecov
+        if: matrix.tomcat-version == '11.0.22'
         uses: codecov/codecov-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Create release
+
+on:
+  pull_request_target:
+    branches:
+      - 2.x
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+concurrency: release-${{ github.event.pull_request.base.ref }}
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          check-latest: true
+          cache: gradle
+
+      - name: Set build parameters
+        id: build-parameters
+        run: |
+          echo "tomcat-version=11.0.22" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release version
+        id: release-version
+        run: |
+          git fetch --tags --force
+          bash scripts/validate-release-version.sh
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
+      - name: Build
+        run: ./gradlew build -PtomcatVersion="${{ steps.build-parameters.outputs.tomcat-version }}"
+
+      - name: Bump git tag and create GitHub Release
+        run: |
+          git config --global user.name 'islandora-community'
+          git config --global user.email 'islandora-community@users.noreply.github.com'
+
+          git tag "$TAG"
+          git push origin "$TAG"
+
+          plain_jar="build/libs/islandora-syn-${VERSION}.jar"
+          all_jar="build/libs/islandora-syn-${VERSION}-all.jar"
+
+          if [ ! -f "$plain_jar" ] || [ ! -f "$all_jar" ]; then
+            echo "Expected release jars were not found:"
+            echo "  $plain_jar"
+            echo "  $all_jar"
+            exit 1
+          fi
+
+          gh release create "$TAG" --title "$TAG" --generate-notes "$plain_jar" "$all_jar"
+        env:
+          VERSION: ${{ steps.release-version.outputs.version }}
+          TAG: ${{ steps.release-version.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@ plugins {
 }
 
 def projectName = 'islandora-syn'
-def projectVersion = '2.0.0-SNAPSHOT'
+def projectVersion = '2.0.1'
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
-def tomcatVersion = '10.1.42'
+def tomcatVersion = project.findProperty('tomcatVersion') ?: '11.0.22'
 
 checkstyle {
     configFile = rootProject.file('gradle/checkstyle/checkstyle.xml')
@@ -39,7 +39,7 @@ dependencies {
 test {
     // Mockito's inline mock maker self-attaches a Byte Buddy agent to the test JVM.
     // JDK 21 disables self-attachment by default, so enable it explicitly.
-    jvmArgs '-Djdk.attach.allowAttachSelf=true', '-XX:+EnableDynamicAgentLoading'
+    jvmArgs '-Djdk.attach.allowAttachSelf=true', '-XX:+EnableDynamicAgentLoading', '-XX:+StartAttachListener'
 }
 
 jacocoTestReport {

--- a/scripts/validate-release-version.sh
+++ b/scripts/validate-release-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=$(sed -n "s/^def projectVersion = '\([^']*\)'/\1/p" build.gradle | head -n 1)
+if [ -z "$version" ]; then
+  echo "Unable to read projectVersion from build.gradle"
+  exit 1
+fi
+
+case "${BASE_REF:?BASE_REF is required}" in
+  1.x)
+    major=1
+    ;;
+  2.x)
+    major=2
+    ;;
+  *)
+    echo "Unsupported release branch: $BASE_REF"
+    exit 1
+    ;;
+esac
+
+if [[ ! "$version" =~ ^${major}\.[0-9]+\.[0-9]+$ ]]; then
+  echo "projectVersion must be a ${major}.x.x release version without -SNAPSHOT: $version"
+  exit 1
+fi
+
+tag="v${version}"
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+  echo "Release tag already exists: $tag"
+  exit 1
+fi
+
+if [ "${REQUIRE_VERSION_BUMP:-false}" = "true" ]; then
+  base_version=$(git show "origin/${BASE_REF}:build.gradle" |
+    sed -n "s/^def projectVersion = '\([^']*\)'/\1/p" |
+    head -n 1)
+
+  if [ "$version" = "$base_version" ]; then
+    echo "projectVersion must be bumped from ${base_version} before merging"
+    exit 1
+  fi
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "version=$version" >> "$GITHUB_OUTPUT"
+  echo "tag=$tag" >> "$GITHUB_OUTPUT"
+fi
+
+echo "Validated release version ${version} for ${BASE_REF}"

--- a/src/main/java/ca/islandora/syn/valve/SynValve.java
+++ b/src/main/java/ca/islandora/syn/valve/SynValve.java
@@ -259,7 +259,7 @@ public class SynValve extends ValveBase {
         mb.setString(String.join(",", roles));
         final List<String> fedoraRole = Arrays
                 .asList(roles.stream().anyMatch(t -> t.equalsIgnoreCase(adminUserRole)) ? "fedoraAdmin" : "fedoraUser");
-        final GenericPrincipal principal = new GenericPrincipal(username, null, fedoraRole);
+        final GenericPrincipal principal = new GenericPrincipal(username, fedoraRole);
         request.setUserPrincipal(principal);
     }
 


### PR DESCRIPTION
# What does this Pull Request do?

When i cut a release for 2.x i realized to get the JAR into buildkit I needed to run `gradlew build` locally and upload the assets to the GitHub release. This PR does this automatically when merging into 2.x. If this approach is acceptable I'll add the same release cadence to the 1.x branch, too.

I also added tests for tomcat10 and tomcat11 in the CI. And ensure the semver tag is bumped in the gradle file and doesn't clobber an existing tag

This also fixes a bug running Syn in tomcat 11 which is why I started on this PR 😄 https://github.com/Islandora/Syn/pull/30/commits/4992121b45e67bcdb1a6704b6167d3268e40a3dc

# Testing

Tested on fcrepo 7 via https://github.com/Islandora-Devops/isle-buildkit/pull/577/commits/e2462146398ecb47c05ae18932346ca0eb8fef74

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
